### PR TITLE
UX Improvements, fixes: local testnet, snippets etc.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1265,6 +1265,11 @@
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
     },
+    "ps-list": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/ps-list/-/ps-list-7.2.0.tgz",
+      "integrity": "sha512-v4Bl6I3f2kJfr5o80ShABNHAokIgY+wFDTQfE+X3zWYgSGQOCBeYptLZUpoOALBqO5EawmDN/tjTldJesd0ujQ=="
+    },
     "psl": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",

--- a/package.json
+++ b/package.json
@@ -333,6 +333,7 @@
 	},
 	"dependencies": {
 		"glob": "^7.1.6",
+		"ps-list": "^7.2.0",
 		"request": "^2.88.2",
 		"underscore": "^1.10.2"
 	},

--- a/package.json
+++ b/package.json
@@ -92,6 +92,11 @@
 				"command": "elrond.gotoContract",
 				"title": "Show in Explorer",
 				"category": "Elrond"
+			},
+			{
+				"command": "elrond.runTestnet",
+				"title": "Run Local Testnet",
+				"category": "Elrond"
 			}
 		],
 		"menus": {
@@ -140,6 +145,11 @@
 					"command": "elrond.runArwenDebugTests",
 					"when": "explorerResourceIsFolder && resourceFilename != output && resourceFilename != debug && resourceFilename != target",
 					"group": "Elrond"
+				},
+				{
+					"command": "elrond.runTestnet",
+					"when": "explorerResourceIsFolder && resourceFilename != output && resourceFilename != debug && resourceFilename != target",
+					"group": "Elrond Testnet"
 				}
 			],
 			"commandPalette": [
@@ -177,6 +187,10 @@
 				},
 				{
 					"command": "elrond.gotoContract",
+					"when": "false"
+				},
+				{
+					"command": "elrond.runTestnet",
 					"when": "false"
 				}
 			],
@@ -217,6 +231,11 @@
 				{
 					"command": "elrond.gotoContract",
 					"when": "view == smartContracts && viewItem == contract"
+				},
+				{
+					"command": "elrond.runTestnet",
+					"when": "view == smartContracts && viewItem == contract",
+					"group": "Elrond Testnet"
 				},
 				{
 					"command": "elrond.newFromTemplate",

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
 			},
 			{
 				"command": "elrond.gotoContract",
-				"title": "Show in Explorer",
+				"title": "Show in Workspace Explorer",
 				"category": "Elrond"
 			},
 			{

--- a/package.json
+++ b/package.json
@@ -94,8 +94,18 @@
 				"category": "Elrond"
 			},
 			{
-				"command": "elrond.runTestnet",
-				"title": "Run Local Testnet",
+				"command": "elrond.runFreshTestnet",
+				"title": "Start Fresh Testnet",
+				"category": "Elrond"
+			},
+			{
+				"command": "elrond.resumeExistingTestnet",
+				"title": "Resume Testnet",
+				"category": "Elrond"
+			},
+			{
+				"command": "elrond.stopTestnet",
+				"title": "Stop Testnet",
 				"category": "Elrond"
 			}
 		],
@@ -147,8 +157,18 @@
 					"group": "Elrond"
 				},
 				{
-					"command": "elrond.runTestnet",
-					"when": "explorerResourceIsFolder && resourceFilename != output && resourceFilename != debug && resourceFilename != target",
+					"command": "elrond.runFreshTestnet",
+					"when": "resourceFilename == testnet.toml",
+					"group": "Elrond Testnet"
+				},
+				{
+					"command": "elrond.resumeExistingTestnet",
+					"when": "resourceFilename == testnet.toml",
+					"group": "Elrond Testnet"
+				},
+				{
+					"command": "elrond.stopTestnet",
+					"when": "resourceFilename == testnet.toml",
 					"group": "Elrond Testnet"
 				}
 			],
@@ -190,7 +210,15 @@
 					"when": "false"
 				},
 				{
-					"command": "elrond.runTestnet",
+					"command": "elrond.runFreshTestnet",
+					"when": "false"
+				},
+				{
+					"command": "elrond.resumeExistingTestnet",
+					"when": "false"
+				},
+				{
+					"command": "elrond.stopTestnet",
 					"when": "false"
 				}
 			],
@@ -231,11 +259,6 @@
 				{
 					"command": "elrond.gotoContract",
 					"when": "view == smartContracts && viewItem == contract"
-				},
-				{
-					"command": "elrond.runTestnet",
-					"when": "view == smartContracts && viewItem == contract",
-					"group": "Elrond Testnet"
 				},
 				{
 					"command": "elrond.newFromTemplate",

--- a/package.json
+++ b/package.json
@@ -238,7 +238,7 @@
 			"activitybar": [
 				{
 					"id": "elrond",
-					"title": "Elrond Explorer",
+					"title": "Elrond Workspace Explorer",
 					"icon": "content/logo.png"
 				}
 			]

--- a/src/environment.ts
+++ b/src/environment.ts
@@ -15,10 +15,12 @@ export class Environment {
         let arwentoolsFolder = path.join(sdkPath, "arwentools");
         let rustFolder = path.join(sdkPath, "vendor-rust");
         let rustBinFolder = path.join(rustFolder, "bin");
+        let nodeJsFolder = path.join(sdkPath, "nodejs", "latest");
+        let nodeJsBinFolder = path.join(nodeJsFolder, "bin");
 
         // This is required for other VS Code extensions to work well and use the custom (Rust) environment.
         delete process.env["PYTHONHOME"];
-        process.env["PATH"] = `${rustBinFolder}:${erdpyBinFolder}:${arwentoolsFolder}:${process.env["PATH"]}`;
+        process.env["PATH"] = `${rustBinFolder}:${erdpyBinFolder}:${arwentoolsFolder}:${nodeJsBinFolder}:${process.env["PATH"]}`;
         process.env["VIRTUAL_ENV"] = erdpyEnvFolder;
         process.env["RUSTUP_HOME"] = rustFolder;
         process.env["CARGO_HOME"] = rustFolder;
@@ -31,9 +33,11 @@ export class Environment {
         let arwentoolsFolder = path.join(sdkPath, "arwentools");
         let rustFolder = path.join(sdkPath, "vendor-rust");
         let rustBinFolder = path.join(rustFolder, "bin");
+        let nodeJsFolder = path.join(sdkPath, "nodejs", "latest");
+        let nodeJsBinFolder = path.join(nodeJsFolder, "bin");
 
         return {
-            "PATH": rustBinFolder + ":" + erdpyBinFolder + ":" + arwentoolsFolder + ":" + "${env:PATH}",
+            "PATH": `${rustBinFolder}:${erdpyBinFolder}:${arwentoolsFolder}:${nodeJsBinFolder}:\${env:PATH}`,
             "VIRTUAL_ENV": erdpyEnvFolder,
             "RUSTUP_HOME": rustFolder,
             "CARGO_HOME": rustFolder
@@ -47,10 +51,12 @@ export class Environment {
         let arwentoolsFolder = path.join(sdkPath, "arwentools");
         let rustFolder = path.join(sdkPath, "vendor-rust");
         let rustBinFolder = path.join(rustFolder, "bin");
+        let nodeJsFolder = path.join(sdkPath, "nodejs", "latest");
+        let nodeJsBinFolder = path.join(nodeJsFolder, "bin");
 
         return {
             "PYTHONHOME": null,
-            "PATH": `${rustBinFolder}:${erdpyBinFolder}:${arwentoolsFolder}:${process.env["PATH"]}`,
+            "PATH": `${rustBinFolder}:${erdpyBinFolder}:${arwentoolsFolder}:${nodeJsBinFolder}:${process.env["PATH"]}`,
             "VIRTUAL_ENV": erdpyEnvFolder,
             "RUSTUP_HOME": rustFolder,
             "CARGO_HOME": rustFolder

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -32,6 +32,7 @@ export async function activate(context: vscode.ExtensionContext) {
 	vscode.commands.registerCommand("elrond.runContractSnippet", runContractSnippet);
 	vscode.commands.registerCommand("elrond.runMandosTests", runMandosTests);
 	vscode.commands.registerCommand("elrond.runArwenDebugTests", runArwenDebugTests);
+	vscode.commands.registerCommand("elrond.runTestnet", runTestnet);
 
 	vscode.commands.registerCommand("elrond.cleanContract", cleanContract);
 	vscode.commands.registerCommand("elrond.refreshTemplates", async () => await refreshViewModel(templatesViewModel));
@@ -165,6 +166,15 @@ async function runArwenDebugTests(contract: SmartContract) {
 	try {
 		let folder = getContractFolder(contract);
 		await sdk.runArwenDebugTests(folder);
+	} catch (error) {
+		errors.caughtTopLevel(error);
+	}
+}
+
+async function runTestnet(contract: SmartContract) {
+	try {
+		let folder = getContractFolder(contract);
+		await sdk.runTestnet(folder);
 	} catch (error) {
 		errors.caughtTopLevel(error);
 	}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,7 +1,6 @@
 import * as vscode from 'vscode';
 import { Root } from './root';
 import { Feedback } from './feedback';
-import _ = require('underscore');
 import * as sdk from "./sdk";
 import { TemplatesViewModel as TemplatesViewModel, ContractTemplate } from './templates';
 import * as workspace from "./workspace";

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -32,7 +32,9 @@ export async function activate(context: vscode.ExtensionContext) {
 	vscode.commands.registerCommand("elrond.runContractSnippet", runContractSnippet);
 	vscode.commands.registerCommand("elrond.runMandosTests", runMandosTests);
 	vscode.commands.registerCommand("elrond.runArwenDebugTests", runArwenDebugTests);
-	vscode.commands.registerCommand("elrond.runTestnet", runTestnet);
+	vscode.commands.registerCommand("elrond.runFreshTestnet", runFreshTestnet);
+	vscode.commands.registerCommand("elrond.resumeExistingTestnet", resumeExistingTestnet);
+	vscode.commands.registerCommand("elrond.stopTestnet", stopTestnet);
 
 	vscode.commands.registerCommand("elrond.cleanContract", cleanContract);
 	vscode.commands.registerCommand("elrond.refreshTemplates", async () => await refreshViewModel(templatesViewModel));
@@ -137,7 +139,7 @@ async function runContractSnippet(contract: any) {
 
 function getContractFolder(contract: any): string {
 	if (contract instanceof Uri) {
-		let fsPath = (contract as Uri).fsPath;
+		let fsPath = contract.fsPath;
 		if (fsPath.includes("elrond.json")) {
 			return path.dirname(fsPath);
 		} else if (fsPath.includes("snippets.sh")) {
@@ -153,7 +155,7 @@ function getContractFolder(contract: any): string {
 async function runMandosTests(item: any) {
 	try {
 		if (item instanceof Uri) {
-			await sdk.runMandosTests((item as Uri).fsPath);
+			await sdk.runMandosTests(item.fsPath);
 		} else {
 			await sdk.runMandosTests((item as SmartContract).getPath());
 		}
@@ -171,10 +173,25 @@ async function runArwenDebugTests(contract: SmartContract) {
 	}
 }
 
-async function runTestnet(contract: SmartContract) {
+async function runFreshTestnet(testnetToml: Uri) {
 	try {
-		let folder = getContractFolder(contract);
-		await sdk.runTestnet(folder);
+		await sdk.runFreshTestnet(testnetToml);
+	} catch (error) {
+		errors.caughtTopLevel(error);
+	}
+}
+
+async function resumeExistingTestnet(testnetToml: Uri) {
+	try {
+		await sdk.resumeExistingTestnet(testnetToml);
+	} catch (error) {
+		errors.caughtTopLevel(error);
+	}
+}
+
+async function stopTestnet(testnetToml: Uri) {
+	try {
+		await sdk.stopTestnet(testnetToml);
 	} catch (error) {
 		errors.caughtTopLevel(error);
 	}

--- a/src/feedback.ts
+++ b/src/feedback.ts
@@ -1,5 +1,4 @@
 import * as vscode from 'vscode';
-import _ = require('underscore');
 
 export class Feedback {
     private static OutputChannels: { [id: string]: vscode.OutputChannel; } = {};

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -8,7 +8,8 @@ import * as presenter from './presenter';
 import { Environment } from './environment';
 
 
-let MinErdpyVersion = "0.8.9";
+let MinErdpyVersion = "0.9.1";
+let Erdpy = "erdpy";
 
 export function getPath() {
     return MySettings.getElrondSdk();
@@ -36,7 +37,7 @@ async function ensureErdpy() {
 
 async function isErdpyInstalled(): Promise<boolean> {
     let [version, ok] = await getOneLineStdout("erdpy", ["--version"]);
-    let isNewer = version >= `erdpy ${MinErdpyVersion}`;
+    let isNewer = version >= `${Erdpy} ${MinErdpyVersion}`;
     return ok && isNewer;
 }
 
@@ -76,7 +77,7 @@ export async function reinstallErdpy(version: string) {
 export async function fetchTemplates(cacheFile: string) {
     try {
         await ProcessFacade.execute({
-            program: "erdpy",
+            program: Erdpy,
             args: ["contract", "templates"],
             doNotDumpStdout: true,
             stdoutToFile: cacheFile
@@ -91,7 +92,7 @@ export async function fetchTemplates(cacheFile: string) {
 export async function newFromTemplate(folder: string, template: string, name: string) {
     try {
         await ProcessFacade.execute({
-            program: "erdpy",
+            program: Erdpy,
             args: ["contract", "new", "--directory", folder, "--template", template, name],
         });
 
@@ -151,7 +152,7 @@ async function ensureInstalledErdpyGroup(group: string) {
 }
 
 async function isErdpyGroupInstalled(group: string, version: string = ""): Promise<boolean> {
-    let [_, ok] = await getOneLineStdout("erdpy", ["deps", "check", group]);
+    let [_, ok] = await getOneLineStdout(Erdpy, ["deps", "check", group]);
     return ok;
 }
 
@@ -164,7 +165,7 @@ export async function reinstallModule(): Promise<void> {
 async function reinstallErdpyGroup(group: string, version: string = "") {
     Feedback.info(`Installation of ${group} has been started. Please wait for installation to finish.`);
     let tagArgument = version ? `--tag=${version}` : "";
-    await runInTerminal("installer", `erdpy --verbose deps install ${group} --overwrite ${tagArgument}`, null, true);
+    await runInTerminal("installer", `${Erdpy} --verbose deps install ${group} --overwrite ${tagArgument}`, null, true);
 
     do {
         Feedback.debug("Waiting for the installer to finish.");
@@ -176,7 +177,7 @@ async function reinstallErdpyGroup(group: string, version: string = "") {
 
 export async function buildContract(folder: string) {
     try {
-        await runInTerminal("build", `erdpy --verbose contract build "${folder}"`, null);
+        await runInTerminal("build", `${Erdpy} --verbose contract build "${folder}"`, null);
     } catch (error) {
         throw new errors.MyError({ Message: "Could not build Smart Contract", Inner: error });
     }
@@ -184,7 +185,7 @@ export async function buildContract(folder: string) {
 
 export async function cleanContract(folder: string) {
     try {
-        await runInTerminal("build", `erdpy --verbose contract clean "${folder}"`, null);
+        await runInTerminal("build", `${Erdpy} --verbose contract clean "${folder}"`, null);
     } catch (error) {
         throw new errors.MyError({ Message: "Could not clean Smart Contract", Inner: error });
     }

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -37,7 +37,7 @@ async function ensureErdpy() {
 }
 
 async function isErdpyInstalled(): Promise<boolean> {
-    let [version, ok] = await getOneLineStdout("erdpy", ["--version"]);
+    let [version, ok] = await getOneLineStdout(Erdpy, ["--version"]);
     let isNewer = version >= `${Erdpy} ${MinErdpyVersion}`;
     return ok && isNewer;
 }

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -1,5 +1,5 @@
 import { Feedback } from './feedback';
-import { ProcessFacade, RestFacade } from "./utils";
+import { ProcessFacade, RestFacade, sleep } from "./utils";
 import { Terminal, Uri, window } from 'vscode';
 import { MySettings } from './settings';
 import * as storage from "./storage";
@@ -49,7 +49,7 @@ async function getOneLineStdout(program: string, args: string[]): Promise<[strin
             args: args
         });
 
-        return [result.stdOut, true];
+        return [result.stdout, true];
     } catch (e) {
         return ["", false];
     }
@@ -149,10 +149,6 @@ async function killRunningInTerminal(name: string) {
     }
 
     terminal.sendText("\u0003");
-}
-
-async function sleep(milliseconds: number) {
-    return new Promise(resolve => setTimeout(resolve, milliseconds));
 }
 
 export async function ensureInstalledBuildchains(languages: string[]) {

--- a/src/snippets.ts
+++ b/src/snippets.ts
@@ -19,7 +19,7 @@ export async function runContractSnippet(folder: string) {
     if (!choice) {
         return;
     }
-    
+
     let terminalName = `Elrond snippets: ${metadata.ProjectName}`;
     let command = `source ${snippetsFile} && ${choice}`;
     await runInTerminal(terminalName, command, folder);
@@ -32,10 +32,19 @@ function getSnippetsNames(file: string): string[] {
 }
 
 async function runInTerminal(terminalName: string, command: string, contractFolder: string) {
+    let envTestnet = path.join(contractFolder, "testnet");
+    let envWallets = path.join(envTestnet, "wallets");
+    let envUsers = path.join(envWallets, "users");
+
     let terminal = window.terminals.find(item => item.name == terminalName);
     if (!terminal) {
-        let env = { CONTRACT_FOLDER: contractFolder };
-        terminal = window.createTerminal({ name: terminalName, env: env });
+        let env = { 
+            PROJECT: contractFolder,
+            TESTNET: envTestnet,
+            WALLETS: envWallets,
+            USERS: envUsers
+        };
+        terminal = window.createTerminal({ name: terminalName, env: env, cwd: contractFolder });
     }
 
     terminal.sendText(command);

--- a/src/snippets.ts
+++ b/src/snippets.ts
@@ -4,6 +4,8 @@ import * as presenter from './presenter';
 import * as workspace from './workspace';
 import { window } from 'vscode';
 import * as errors from './errors';
+import { waitForProcessInTerminal } from "./utils";
+import { Feedback } from "./feedback";
 
 
 export async function runContractSnippet(folder: string) {
@@ -23,6 +25,7 @@ export async function runContractSnippet(folder: string) {
     let terminalName = `Elrond snippets: ${metadata.ProjectName}`;
     let command = `source ${snippetsFile} && ${choice}`;
     await runInTerminal(terminalName, command, folder);
+    Feedback.info(`Snippet "${choice}" has been executed. Check output in Terminal.`);
 }
 
 function getSnippetsNames(file: string): string[] {
@@ -49,4 +52,5 @@ async function runInTerminal(terminalName: string, command: string, contractFold
 
     terminal.sendText(command);
     terminal.show(false);
+    await waitForProcessInTerminal(terminal);
 }

--- a/src/snippets.ts
+++ b/src/snippets.ts
@@ -24,7 +24,7 @@ export async function runContractSnippet(folder: string) {
 
     let terminalName = `Elrond snippets: ${metadata.ProjectName}`;
     let command = `source ${snippetsFile} && ${choice}`;
-    await runInTerminal(terminalName, command, folder);
+    await runInTerminal(terminalName, command, metadata);
     Feedback.info(`Snippet "${choice}" has been executed. Check output in Terminal.`);
 }
 
@@ -34,20 +34,21 @@ function getSnippetsNames(file: string): string[] {
     return found;
 }
 
-async function runInTerminal(terminalName: string, command: string, contractFolder: string) {
-    let envTestnet = path.join(contractFolder, "testnet");
+async function runInTerminal(terminalName: string, command: string, metadata: workspace.ProjectMetadata) {
+    let envTestnet = path.join(metadata.ProjectPath, "testnet");
     let envWallets = path.join(envTestnet, "wallets");
     let envUsers = path.join(envWallets, "users");
 
     let terminal = window.terminals.find(item => item.name == terminalName);
     if (!terminal) {
         let env = { 
-            PROJECT: contractFolder,
+            PROJECT: metadata.ProjectPath,
+            PROJECT_NAME: metadata.ProjectName,
             TESTNET: envTestnet,
             WALLETS: envWallets,
             USERS: envUsers
         };
-        terminal = window.createTerminal({ name: terminalName, env: env, cwd: contractFolder });
+        terminal = window.createTerminal({ name: terminalName, env: env, cwd: metadata.ProjectPath });
     }
 
     terminal.sendText(command);

--- a/src/snippets.ts
+++ b/src/snippets.ts
@@ -16,6 +16,10 @@ export async function runContractSnippet(folder: string) {
 
     let snippets = getSnippetsNames(snippetsFile);
     let choice = await presenter.askChoice(snippets);
+    if (!choice) {
+        return;
+    }
+    
     let terminalName = `Elrond snippets: ${metadata.ProjectName}`;
     let command = `source ${snippetsFile} && ${choice}`;
     await runInTerminal(terminalName, command, folder);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -9,6 +9,7 @@ import _ = require('underscore');
 import { Feedback } from './feedback';
 import { MyExecError, MyHttpError, MyError } from './errors';
 import { Terminal } from 'vscode';
+const psList = require('ps-list');
 
 export class ProcessFacade {
     public static execute(options: any): Promise<any> {
@@ -432,14 +433,11 @@ export async function waitForProcessInTerminal(terminal: Terminal): Promise<void
         while (true) {
             await sleep(250);
 
-            let result = await ProcessFacade.execute({
-                program: "ps",
-                args: ["--no-headers", "--ppid", pid],
-                collectStdOut: true
-            });
-
+            let result: any[] = await psList({ all: true });
+            let hasChildren = result.some(item => item.ppid == pid);
+            
             // No more child processes running in the Terminal.
-            if (!result.stdout) {
+            if (!hasChildren) {
                 break;
             }
         }

--- a/src/workspace.ts
+++ b/src/workspace.ts
@@ -30,6 +30,7 @@ export async function setup() {
     ensureFolder(".vscode");
     ensureWorkspaceDefinitionFile();
     await patchSettings();
+    setupGitignore();
 }
 
 
@@ -253,5 +254,15 @@ export class ProjectMetadata {
         if (!languages.includes(this.Language)) {
             throw new errors.MyError({ Message: `Bad project metadata: ${metadataFile}` });
         }
+    }
+}
+
+function setupGitignore() {
+    let filePath = path.join(getPath(), ".gitignore");
+    if (!fs.existsSync(filePath)) {
+        fs.writeFileSync(filePath, `output/**
+testnet/**
+**/workspace.storage.json
+`);
     }
 }

--- a/src/workspace.ts
+++ b/src/workspace.ts
@@ -262,7 +262,7 @@ function setupGitignore() {
     if (!fs.existsSync(filePath)) {
         fs.writeFileSync(filePath, `output/**
 testnet/**
-**/workspace.storage.json
+**/erdpy.data-storage.json
 `);
     }
 }


### PR DESCRIPTION
- Run local testnet (start, stop, start fresh) from contextual menu. Enhance terminals.
- Skip running snippet if none chosen (bugfix).
- Pass extra variables into running snippets.
- Improve snippets. Integrate with "erdpy data".
- For snippets, wait for process in Terminal to finish.
- Setup workspace - add .gitignore file if missing.
- Reference newest erdpy.