### PR TITLE
Better snippets. Reference new erdpy.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vscode-elrond-ide",
-  "version": "0.7.7",
+  "version": "0.7.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "vscode-elrond-ide",
 	"displayName": "Elrond IDE",
 	"description": "Elrond IDE for developing Smart Contracts",
-	"version": "0.7.7",
+	"version": "0.7.8",
 	"publisher": "Elrond",
 	"repository": {
 		"type": "git",

--- a/package.json
+++ b/package.json
@@ -138,7 +138,7 @@
 				},
 				{
 					"command": "elrond.runContractSnippet",
-					"when": "resourceFilename == elrond.json || resourceFilename == snippets.sh",
+					"when": "resourceFilename == elrond.json",
 					"group": "Elrond"
 				},
 				{

--- a/src/presenter.ts
+++ b/src/presenter.ts
@@ -89,3 +89,7 @@ export async function askYesNo(question: string): Promise<boolean> {
 export async function askChoice(choices: string[]): Promise<string> {
     return await vscode.window.showQuickPick(choices, { ignoreFocusOut: true });
 }
+
+export async function askChoiceTyped<T extends vscode.QuickPickItem>(choices: T[]): Promise<T> {
+    return await vscode.window.showQuickPick<T>(choices, { ignoreFocusOut: true });
+}

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -9,7 +9,7 @@ import { Environment } from './environment';
 import path = require("path");
 
 
-let MinErdpyVersion = "0.9.5";
+let MinErdpyVersion = "0.9.8";
 let Erdpy = "erdpy";
 
 export function getPath() {

--- a/src/snippets.ts
+++ b/src/snippets.ts
@@ -11,11 +11,11 @@ import { glob } from "glob";
 
 export async function runContractSnippet(folder: string) {
     let metadata = workspace.getMetadataObjectByFolder(folder);
-    let pattern = `${folder}/**/*.snippets.sh`;
+    let pattern = `${folder}/**/*snippets.sh`;
     let snippetsFiles = glob.sync(pattern, {});
 
     if (!snippetsFiles.length) {
-        throw new errors.MyError({ Message: `No *.snippets.sh file found.` });
+        throw new errors.MyError({ Message: `No *snippets.sh file found.` });
     }
     
     let allSnippets: Snippet[] = [];
@@ -77,7 +77,9 @@ export class Snippet implements QuickPickItem {
     constructor(file: string, name: string) {
         this.file = file;
         this.name = name;
-        this.label = `${path.basename(file)}: ${name}`;
+
+        let fileLabel = path.basename(file).replace(".snippets.sh", "");
+        this.label = `${fileLabel}: ${name}`;
     }
 
     toString(): string {

--- a/src/snippets.ts
+++ b/src/snippets.ts
@@ -2,30 +2,39 @@ import path = require("path");
 import fs = require("fs");
 import * as presenter from './presenter';
 import * as workspace from './workspace';
-import { window } from 'vscode';
+import { QuickPickItem, window } from 'vscode';
 import * as errors from './errors';
 import { waitForProcessInTerminal } from "./utils";
 import { Feedback } from "./feedback";
+import { glob } from "glob";
 
 
 export async function runContractSnippet(folder: string) {
     let metadata = workspace.getMetadataObjectByFolder(folder);
-    let snippetsFile = path.join(folder, "snippets.sh");
+    let pattern = `${folder}/**/*.snippets.sh`;
+    let snippetsFiles = glob.sync(pattern, {});
 
-    if (!fs.existsSync(snippetsFile)) {
-        throw new errors.MyError({ Message: `Snippets file is missing: ${snippetsFile}` });
+    if (!snippetsFiles.length) {
+        throw new errors.MyError({ Message: `No *.snippets.sh file found.` });
     }
+    
+    let allSnippets: Snippet[] = [];
 
-    let snippets = getSnippetsNames(snippetsFile);
-    let choice = await presenter.askChoice(snippets);
-    if (!choice) {
+    snippetsFiles.forEach(file => {
+        let names = getSnippetsNames(file);
+        let snippets = names.map(name => new Snippet(file, name));
+        allSnippets.push(...snippets);
+    });
+
+    let snippetChoice = await presenter.askChoiceTyped(allSnippets);
+    if (!snippetChoice) {
         return;
     }
 
     let terminalName = `Elrond snippets: ${metadata.ProjectName}`;
-    let command = `source ${snippetsFile} && ${choice}`;
+    let command = `source ${snippetChoice.file} && ${snippetChoice.name}`;
     await runInTerminal(terminalName, command, metadata);
-    Feedback.info(`Snippet "${choice}" has been executed. Check output in Terminal.`);
+    Feedback.info(`Snippet "${snippetChoice}" has been executed. Check output in Terminal.`);
 }
 
 function getSnippetsNames(file: string): string[] {
@@ -54,4 +63,24 @@ async function runInTerminal(terminalName: string, command: string, metadata: wo
     terminal.sendText(command);
     terminal.show(false);
     await waitForProcessInTerminal(terminal);
+}
+
+export class Snippet implements QuickPickItem {
+    readonly file: string;
+    readonly name: string;
+    readonly label: string;
+    readonly description?: string;
+    readonly detail?: string;
+    readonly picked?: boolean;
+    readonly alwaysShow?: boolean;
+    
+    constructor(file: string, name: string) {
+        this.file = file;
+        this.name = name;
+        this.label = `${path.basename(file)}: ${name}`;
+    }
+
+    toString(): string {
+        return this.label;
+    }
 }

--- a/src/workspace.ts
+++ b/src/workspace.ts
@@ -260,9 +260,17 @@ export class ProjectMetadata {
 function setupGitignore() {
     let filePath = path.join(getPath(), ".gitignore");
     if (!fs.existsSync(filePath)) {
-        fs.writeFileSync(filePath, `output/**
-testnet/**
+        fs.writeFileSync(filePath, `# Elrond IDE
+**/node_modules
+**/output/**
+**/testnet/**
 **/erdpy.data-storage.json
+**/*.interaction.json
 `);
     }
 }
+
+
+
+
+


### PR DESCRIPTION
 - Add support for more `snippets.sh` files (the ones with suffix `*.snippets.sh` are recognized).
 - Do not allow "right-click, run snippets" on `*.snippets.sh` files. Command has to be triggered at contract-level.
 - Reference newest erdpy.