### PR TITLE
Add LLDB pretty printers support for debugging elrond-wasm-rs projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v0.13.0
+ - [Add LLDB pretty printers support for debugging elrond-wasm-rs projects](https://github.com/ElrondNetwork/elrond-ide-vscode/pull/55)
+
 ## v0.12.0
  - [Add support for erdjs-snippets. Additional refactoring & cleanup](https://github.com/ElrondNetwork/elrond-ide-vscode/pull/48)
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Elrond IDE supports the following programming languages:
  - Build Smart Contracts to WASM
  - Step-by-step debugging Rust smart contracts
  - Automatically download tools and dependencies
+ - Rust debugger support for managed types - see [the installation guide](#installing-the-rust-debugger-pretty-printer-script)
 
 ## How to get it
 
@@ -54,6 +55,16 @@ This extension contributes the following commands (`Ctrl+Shift+P`):
 * `cleanContract`
 * `runMandosTests`
 * `runContractSnippet`
+
+## Installing the rust debugger pretty printer script
+
+The rust debugger pretty printer script for LLDB allows proper viewing of managed types (BigUint, ManagedBuffer etc.) when debugging smart contract rust tests.
+
+Prerequisites: First, make sure that the [CodeLLDB](https://github.com/vadimcn/vscode-lldb) extension is installed. This can be done directly from Visual Studio Code extensions menu.
+
+Then, from Visual Studio Code open the command menu via `Ctrl+Shift+P` and run `Elrond: Install the rust debugger pretty printer script`. If this option isn't present, make sure you have the latest version of the `Elrond` Visual Studio Code extension.
+
+You will be prompted for the repository, branch and path for the pretty printer script. Simply leave the options blank in order to install the latest version of the script from elrond-wasm-rs.
 
 ## Contributors
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "vscode-elrond-ide",
-	"version": "0.12.0",
+	"version": "0.13.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "vscode-elrond-ide",
-			"version": "0.12.0",
+			"version": "0.13.0",
 			"dependencies": {
 				"axios": "0.24.0",
 				"glob": "^7.1.6",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "vscode-elrond-ide",
 	"displayName": "Elrond IDE",
 	"description": "Elrond IDE for developing Smart Contracts",
-	"version": "0.12.0",
+	"version": "0.13.0",
 	"publisher": "Elrond",
 	"repository": {
 		"type": "git",
@@ -20,6 +20,7 @@
 	"icon": "content/logo.png",
 	"activationEvents": [
 		"onCommand:elrond.setupWorkspace",
+		"onCommand:elrond.installRustDebuggerPrettyPrinterScript",
 		"workspaceContains:**/elrond.workspace.json"
 	],
 	"main": "./out/extension.js",
@@ -38,6 +39,11 @@
 			{
 				"command": "elrond.installSdkModule",
 				"title": "Install Module or Dependency",
+				"category": "Elrond"
+			},
+			{
+				"command": "elrond.installRustDebuggerPrettyPrinterScript",
+				"title": "Install the rust debugger pretty printer script",
 				"category": "Elrond"
 			},
 			{

--- a/src/erdjsSnippets.ts
+++ b/src/erdjsSnippets.ts
@@ -1,5 +1,5 @@
 import path = require("path");
-import { patchSettings } from "./workspace";
+import { askPatchSettings } from "./workspace";
 import { Feedback } from "./feedback";
 
 export async function setup(destinationFolder: string) {
@@ -13,7 +13,9 @@ export async function setup(destinationFolder: string) {
     let askText = `Allow Elrond IDE to modify this workspace's "settings.json"?
 The changes include setting up the Mocha Test Explorer (and the mocha runner).\n
 For a better experience when using erdjs-based "snippets", we recommed allowing this change.`;
-    await patchSettings(patch, askText);
+
+    let filePath = path.join(".", ".vscode", "settings.json");
+    await askPatchSettings(patch, filePath, askText);
 
     Feedback.info(`"erdjs-snippets" have been set up at the following location: ${erdjsSnippetsFolder}.`);
 }

--- a/src/erdjsSnippets.ts
+++ b/src/erdjsSnippets.ts
@@ -1,5 +1,5 @@
 import path = require("path");
-import { askPatchSettings } from "./workspace";
+import { promptThenPatchSettings } from "./workspace";
 import { Feedback } from "./feedback";
 
 export async function setup(destinationFolder: string) {
@@ -15,7 +15,7 @@ The changes include setting up the Mocha Test Explorer (and the mocha runner).\n
 For a better experience when using erdjs-based "snippets", we recommed allowing this change.`;
 
     let filePath = path.join(".", ".vscode", "settings.json");
-    await askPatchSettings(patch, filePath, askText);
+    await promptThenPatchSettings(patch, filePath, askText);
 
     Feedback.info(`"erdjs-snippets" have been set up at the following location: ${erdjsSnippetsFolder}.`);
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -27,6 +27,7 @@ export async function activate(context: vscode.ExtensionContext) {
 	vscode.commands.registerCommand("elrond.setupWorkspace", setupWorkspace);
 	vscode.commands.registerCommand("elrond.installSdk", installSdk);
 	vscode.commands.registerCommand("elrond.installSdkModule", installSdkModule);
+	vscode.commands.registerCommand("elrond.installRustDebuggerPrettyPrinterScript", installRustDebuggerPrettyPrinterScript);
 	vscode.commands.registerCommand("elrond.gotoContract", gotoContract);
 	vscode.commands.registerCommand("elrond.buildContract", buildContract);
 	vscode.commands.registerCommand("elrond.runContractSnippet", runContractSnippet);
@@ -73,6 +74,14 @@ async function installSdk() {
 async function installSdkModule() {
 	try {
 		await sdk.reinstallModule();
+	} catch (error) {
+		errors.caughtTopLevel(error);
+	}
+}
+
+async function installRustDebuggerPrettyPrinterScript() {
+	try {
+		await sdk.installRustDebuggerPrettyPrinterScript();
 	} catch (error) {
 		errors.caughtTopLevel(error);
 	}

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -11,7 +11,7 @@ import path = require("path");
 import { FreeTextVersion, Version } from './version';
 import fs = require('fs');
 import os = require('os');
-import { patchSettings } from './workspace';
+import { patchSettingsWithoutPrompt } from './workspace';
 
 const Erdpy = "erdpy";
 const DefaultErdpyVersion = new Version(1, 3, 0);
@@ -326,7 +326,7 @@ export async function installRustDebuggerPrettyPrinterScript() {
         ],
     };
     let globalSettingsPath = path.join(os.homedir(), ".config", "Code", "User", "settings.json");
-    await patchSettings(patch, globalSettingsPath);
+    await patchSettingsWithoutPrompt(patch, globalSettingsPath);
 }
 
 async function showInputBoxWithDefault(options: InputBoxOptions & { defaultInput: string }) {

--- a/src/workspace.ts
+++ b/src/workspace.ts
@@ -70,7 +70,7 @@ The changes include setting environment variables for the terminal integrated in
 For a better experience when debugging and building Smart Contracts, we recommed allowing this change.`;
 
     let localSettingsJsonPath = path.join(getPath(), ".vscode", "settings.json");
-    return await askPatchSettings(patch, localSettingsJsonPath, askText);
+    return await promptThenPatchSettings(patch, localSettingsJsonPath, askText);
 }
 
 export async function patchSettingsOnConfirm(patch: any, filePath: string, askForPermission: () => Promise<boolean>): Promise<boolean> {
@@ -107,14 +107,14 @@ export async function patchSettingsOnConfirm(patch: any, filePath: string, askFo
     return true;
 }
 
-export async function askPatchSettings(patch: any, filePath: string, askText: string): Promise<boolean> {
+export async function promptThenPatchSettings(patch: any, filePath: string, askText: string): Promise<boolean> {
     async function askForPermission(): Promise<boolean> {
         return await presenter.askYesNo(askText);
     }
     return await patchSettingsOnConfirm(patch, filePath, askForPermission);
 }
 
-export async function patchSettings(patch: any, filePath: string): Promise<boolean> {
+export async function patchSettingsWithoutPrompt(patch: any, filePath: string): Promise<boolean> {
     async function askForPermission(): Promise<boolean> {
         return true;
     }


### PR DESCRIPTION
Added `Elrond: Install the rust debugger pretty printer script` command in the VS code command palette which installs the rust debugger pretty printer script introduced in https://github.com/ElrondNetwork/elrond-wasm-rs/pull/825
  - See the `Installing the rust debugger pretty printer script` section in `README.md` for more details

Notes for installing the Elrond VS code extension locally (for testing the install command before the Elrond extension release):
- clone and checkout the `[add-elrond-wasm-lldb-pretty-printers](https://github.com/ElrondNetwork/elrond-ide-vscode/tree/add-elrond-wasm-lldb-pretty-printers)` branch
- [install `vsce`](https://code.visualstudio.com/api/working-with-extensions/publishing-extension#installation) if you don't have it already
- then package and install the extension: `vsce package && code --install-extension vscode-elrond-ide-0.13.0.vsix`
- from VS code press `Ctrl+Shift+P` and run `Developer: Reload Window`
- follow the installation instructions from the `README.md`, EXCEPT when prompted for the branch - enter `lldb-pretty-printers` (if PR https://github.com/ElrondNetwork/elrond-wasm-rs/pull/825 hasn't been merged to master yet)