### PR TITLE
Fix the settings update when modifying the lldb global config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v0.13.1
+ - [Fix the settings update when modifying the lldb global config](https://github.com/ElrondNetwork/elrond-ide-vscode/pull/56)
+
 ## v0.13.0
  - [Add LLDB pretty printers support for debugging elrond-wasm-rs projects](https://github.com/ElrondNetwork/elrond-ide-vscode/pull/55)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "vscode-elrond-ide",
-	"version": "0.13.0",
+	"version": "0.13.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "vscode-elrond-ide",
-			"version": "0.13.0",
+			"version": "0.13.1",
 			"dependencies": {
 				"axios": "0.24.0",
 				"glob": "^7.1.6",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "vscode-elrond-ide",
 	"displayName": "Elrond IDE",
 	"description": "Elrond IDE for developing Smart Contracts",
-	"version": "0.13.0",
+	"version": "0.13.1",
 	"publisher": "Elrond",
 	"repository": {
 		"type": "git",

--- a/src/workspace.ts
+++ b/src/workspace.ts
@@ -73,7 +73,7 @@ For a better experience when debugging and building Smart Contracts, we recommed
     return await promptThenPatchSettings(patch, localSettingsJsonPath, askText);
 }
 
-export async function patchSettingsOnConfirm(patch: any, filePath: string, askForPermission: () => Promise<boolean>): Promise<boolean> {
+export async function promptThenPatchSettings(patch: any, filePath: string, askText: string): Promise<boolean> {
     if (!fs.existsSync(filePath)) {
         fs.writeFileSync(filePath, "{}");
     }
@@ -95,7 +95,7 @@ export async function patchSettingsOnConfirm(patch: any, filePath: string, askFo
 
     // Patch has been applied in-memory, and now we have to update the file (settings.json).
     // Ask for permission.
-    let allow = await askForPermission();
+    let allow = await presenter.askYesNo(askText);
     if (!allow) {
         return false;
     }
@@ -105,20 +105,6 @@ export async function patchSettingsOnConfirm(patch: any, filePath: string, askFo
     Feedback.info(`Updated ${filePath}.`);
 
     return true;
-}
-
-export async function promptThenPatchSettings(patch: any, filePath: string, askText: string): Promise<boolean> {
-    async function askForPermission(): Promise<boolean> {
-        return await presenter.askYesNo(askText);
-    }
-    return await patchSettingsOnConfirm(patch, filePath, askForPermission);
-}
-
-export async function patchSettingsWithoutPrompt(patch: any, filePath: string): Promise<boolean> {
-    async function askForPermission(): Promise<boolean> {
-        return true;
-    }
-    return await patchSettingsOnConfirm(patch, filePath, askForPermission);
 }
 
 export function guardIsOpen(): boolean {


### PR DESCRIPTION
- Fix the settings update, as it failed on Mac OS because the path to the global settings is different
- Add a modal announcing on a successful install, because the settings edited toast message is no longer displayed.
- Removed `patchSettingsWithoutPrompt` since it's no longer used.